### PR TITLE
Add telegram notification on PR opened

### DIFF
--- a/.github/workflows/pr-opened-notification.yaml
+++ b/.github/workflows/pr-opened-notification.yaml
@@ -1,0 +1,21 @@
+name: Notify PR Opened
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  notify-telegram:
+    name: Notify PR Opened - Telegram
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Notify Telegram
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+        run: |
+          cd notifications
+          python3 telegram.py pr_opened "${{ github.actor }}" "${{ github.event.pull_request.title }}" "${{ github.event.pull_request.html_url }}"

--- a/notifications/TelegramNotifier.py
+++ b/notifications/TelegramNotifier.py
@@ -1,0 +1,37 @@
+import sys
+
+import requests
+
+
+class TelegramNotifier:
+    def __init__(self, bot_token, chat_id):
+        self.bot_token = bot_token
+        self.chat_id = chat_id
+
+    def notify(self, message, inline_keyboard_markup):
+        url = 'https://api.telegram.org/bot{}/sendMessage'.format(self.bot_token)
+        data = {
+            'chat_id': self.chat_id,
+            'text': message,
+            'parse_mode': 'Markdown',
+            'reply_markup': {
+                'inline_keyboard': inline_keyboard_markup
+            },
+        }
+        print(data)
+        res = requests.post(url, json=data)
+        if res.status_code < 200 or res.status_code >= 300:
+            print("❌ Error sending message:")
+            print(res.text)
+            sys.exit(1)
+
+    def notify_pr_opened(self, pr_author, pr_title, pr_url):
+        with open('templates/pr_opened.txt') as f:
+            message_text = ''.join(f.readlines()).format(pr_author, pr_title, pr_url)
+            print("📩 Sending message:")
+            print(message_text)
+
+            inline_keyboard_markup = [
+                    [{'text': 'View on GitHub', 'url': pr_url}]
+            ]
+            self.notify(message_text, inline_keyboard_markup)

--- a/notifications/telegram.py
+++ b/notifications/telegram.py
@@ -1,0 +1,27 @@
+import sys
+import os
+
+from TelegramNotifier import TelegramNotifier
+
+if __name__ == '__main__':
+    bot_token = os.environ['TELEGRAM_BOT_TOKEN']
+    chat_id = os.environ['TELEGRAM_CHAT_ID']
+
+    if bot_token is None or chat_id is None:
+        print("Please set the TELEGRAM_BOT_TOKEN and TELEGRAM_CHAT_ID environment variables")
+        sys.exit(1)
+    telegram_notifier = TelegramNotifier(bot_token, chat_id)
+
+    if len(sys.argv) < 2:
+        print('Usage: {} <message_type>'.format(sys.argv[0]))
+        sys.exit(1)
+
+    message_type = sys.argv[1]
+    if message_type == 'pr_opened':
+        if len(sys.argv) != 5:
+            print('Usage: {} pr_opened <pr_author> <pr_title> <pr_url>'.format(sys.argv[0]))
+            sys.exit(1)
+        pr_author = sys.argv[2]
+        pr_title = sys.argv[3]
+        pr_url = sys.argv[4]
+        telegram_notifier.notify_pr_opened(pr_author, pr_title, pr_url)

--- a/notifications/templates/pr_opened.txt
+++ b/notifications/templates/pr_opened.txt
@@ -1,0 +1,4 @@
+🔄 *A new Pull Request has been opened!*
+PR Author: `{}`.
+PR Title: _{}_.
+PR URL: `{}`


### PR DESCRIPTION
This PR adds a Telegram notification on opened Pull Requests, to be used when the 'scraper' automatically opens a PR.

It requires two github secrets to be set:
- `TELEGRAM_CHAT_ID`
- `TELEGRAM_BOT_TOKEN`

Which I have set in this repository already.

<img width="545" alt="image" src="https://user-images.githubusercontent.com/1493561/171828969-0e69ea1d-af37-4dcf-85f5-5c984b3a14a1.png">
